### PR TITLE
Stop indexing non-encyclopedia pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ defaults:
     values:
       nav_exclude: true
       numbered_headers: false
+      search_exclude: true
   -
     scope:
       path: _pages/en/encyclopedia
@@ -23,6 +24,7 @@ defaults:
       layout: encyclopedia
       nav_exclude: false
       numbered_headers: true
+      search_exclude: false
 
 exclude:
   - README.md


### PR DESCRIPTION
This doesn't prevent landing pages from being indexed, but I did not find any way to do so.
Adding `search_exclude:true` to the `landing` layout front matter, or to individual landing pages, did not do the trick.