### PR TITLE
[docker-compose] initial version with jekyll-serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Deployment is done with [GitHub Pages](https://pages.github.com). Just push to t
 
 An Nginx reverse proxy is set up on `disinfo.quaidorsay.fr` to serve the content deployed on `ambanum.github.io`.
 
+
+## Run with docker-compose
+
+```sh
+docker-compose up
+```
+
+Open http://localhost:8080
+
 - - -
 
 # License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  jekyll:
+    image: bretfisher/jekyll-serve
+    volumes:
+      - .:/site
+    ports:
+      - '8080:4000'


### PR DESCRIPTION
I'm getting

```
f82d9d71cfa1_disinformationencyclopedia_jekyll_1 | You must use Bundler 2 or greater with this lockfile.
```