### PR TITLE
Make introduction a menu part with children

### DIFF
--- a/_pages/en/encyclopedia/1-introduction/1-case-studies.md
+++ b/_pages/en/encyclopedia/1-introduction/1-case-studies.md
@@ -1,9 +1,8 @@
 ---
-title: Examples of information manipulation campaigns
-permalink: /encyclopedia/examples
-nav_order: 3
-layout: default
-nav_exclude: true
+parent: Introduction
+title: Case studies
+permalink: /encyclopedia/introduction/examples
+nav_order: 1
 ---
 
 # Examples of information manipulation campaigns

--- a/_pages/en/encyclopedia/1-introduction/2-definitions.md
+++ b/_pages/en/encyclopedia/1-introduction/2-definitions.md
@@ -1,9 +1,9 @@
 ---
+parent: Introduction
 title: Definitions
-permalink: /encyclopedia/definitions/
+permalink: /encyclopedia/introduction/definitions
 nav_order: 2
-layout: default
-nav_exclude: false
+numbered_headers: false
 ---
 
 # Definitions

--- a/_pages/en/encyclopedia/1-introduction/index.md
+++ b/_pages/en/encyclopedia/1-introduction/index.md
@@ -1,7 +1,8 @@
 ---
-title: Introduction
-permalink: /encyclopedia
 nav_order: 1
+has_children: true
+permalink: /encyclopedia
+title: Introduction
 numbered_headers: false
 css: home
 ---


### PR DESCRIPTION
This change makes the Introduction page a menu part that has children, and moves both the Definitions and Examples (renamed Case studies to align with other parts) into it.

This means the introduction has an inconsistent URL with its filesystem and navigation locations. I feel it is an acceptable price to pay to keep backwards compatibility, and that we should in the next few weeks make a pass on content architecture to make all this more consistent.

## Before

![](https://user-images.githubusercontent.com/222463/89321354-26e7b280-d683-11ea-849d-1f18bf6c77af.png)

## After

![](https://user-images.githubusercontent.com/222463/89321368-2b13d000-d683-11ea-97c6-8ac8c4a35b7e.png)
